### PR TITLE
Add conditional exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,18 @@
   "author": "The Knockout.js team",
   "main": "build/output/knockout-latest.js",
   "types": "build/types/knockout.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./build/types/knockout.d.ts",
+        "default": "./build/output/knockout-latest.esm.js"
+      },
+      "require": {
+        "types": "./build/types/knockout.d.ts",
+        "default": "./build/output/knockout-latest.js"
+      }
+    }
+  },
   "scripts": {
     "prepublish": "grunt",
     "pretest": "npm run rollup-dev",


### PR DESCRIPTION
This PR adds conditional exports to the package.json, allowing the use of both esm and cjs versions of the library.

NOTE: The main and types fields are left in for backwards compatibility with older versions of node/npm.

Docs:
- https://nodejs.org/api/packages.html#conditional-exports
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing